### PR TITLE
install engines

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,2 +1,3 @@
 ---
 # defaults file for ansible-ansible-container
+engines: [docker] # possible values: docker,k8s,openshift

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -8,4 +8,4 @@
 - name: upgrade setuptools
   pip: name=setuptools state=latest
 - name: installs ansible-container
-  pip: name=ansible-container
+  pip: name=ansible-container['{{ engines | join(",")}}']


### PR DESCRIPTION
according to https://docs.ansible.com/ansible-container/installation.html, when installing with pip, you need to specify the engines your ansible-container installation should support.
This PR introduces a list of engines as role variable, defaulting to [docker]